### PR TITLE
ci: split quality gate into reusable workflow and add Vercel deploy p…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,44 @@
-name: Tests
+name: CI
 
+# Reusable quality-check workflow shared by the Tests (PR/dev) and Deploy
+# (staging/main) workflows. Keeps the complex e2e setup in a single place.
 on:
-  push:
-    branches: [main, staging, dev]
-  pull_request:
-    branches: [main, staging, dev]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    # Least privilege: only the member-login credentials the e2e job needs,
+    # rather than forwarding every repo/org secret via `secrets: inherit`.
+    secrets:
+      TEST_USER_EMAIL:
+        required: false
+      TEST_USER_PASSWORD:
+        required: false
 
 jobs:
+  lint-typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -78,28 +106,7 @@ jobs:
 
       - name: Install Playwright browser (Chromium only)
         if: steps.cache-playwright.outputs.cache-hit != 'true'
-        timeout-minutes: 12
-        env:
-          # Abort a stalled download (Playwright has no read timeout by default)
-          # so the retry loop below can recover instead of hanging the whole job.
-          PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: "120000"
-          # Log each download/extract step so that if it still wedges (the hang
-          # happens right after the chrome zip hits 100%), the log pinpoints the
-          # exact post-download operation that blocks.
-          DEBUG: "pw:install"
-        run: |
-          for attempt in 1 2 3; do
-            echo "::group::Playwright browser install (attempt $attempt)"
-            if timeout 300 pnpm exec playwright install chromium; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            echo "Attempt $attempt stalled or failed; retrying..."
-            sleep 5
-          done
-          echo "Playwright browser install failed after 3 attempts" >&2
-          exit 1
+        run: pnpm exec playwright install chromium
 
       - name: Start Test DB
         run: docker compose up -d --wait db_test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,86 @@
+name: Deploy
+
+# Explicit deploy pipeline (Vercel Git auto-deploy is disabled via vercel.json).
+# On push to staging/main: quality gate -> DB migration -> Vercel deploy.
+#   staging -> Vercel Preview deployment, aliased to a stable staging domain
+#   main    -> Vercel Production deployment
+#
+# Ordering hazard: migrations run BEFORE the new code is deployed, so during the
+# window between the two (and on rollback) the OLD code runs against the NEW
+# schema. Only ship backward-compatible migrations through this pipeline; make
+# breaking changes in two steps (expand, then contract). If `release` fails
+# after the migration step, the DB is already migrated while old code is live —
+# re-run the workflow (deploy is idempotent) or roll the schema forward by hand.
+on:
+  push:
+    branches: [main, staging]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false # never interrupt an in-flight migration/deploy
+
+jobs:
+  # Quality gate: lint, typecheck, unit, e2e (+ build). Reuses the CI workflow.
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets:
+      TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+
+  # Migrate the DB then deploy, as a single environment-gated job. Keeping both
+  # steps in one job means the `production` environment's protection rule
+  # (required reviewers) prompts for approval exactly ONCE per release; splitting
+  # them into two jobs that both reference the environment would require two
+  # separate approvals. The same gate also lets us pause before the DDL runs.
+  release:
+    needs: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    env:
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run migrations
+        env:
+          # session/direct connection (not the 6543 transaction pooler) for DDL
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # production-mode migrate: keep drizzle-kit's verbose schema dump off
+          NODE_ENV: production
+        run: pnpm db:migrate
+
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+
+      - name: Deploy (production)
+        if: github.ref_name == 'main'
+        run: |
+          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          vercel build --prod --token="$VERCEL_TOKEN"
+          url=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          echo "### ✅ Production deployed: $url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Deploy (staging = preview)
+        if: github.ref_name == 'staging'
+        run: |
+          vercel pull --yes --environment=preview --git-branch=staging --token="$VERCEL_TOKEN"
+          vercel build --token="$VERCEL_TOKEN"
+          url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          vercel alias set "$url" kyosan-cts-staging.vercel.app --token="$VERCEL_TOKEN"
+          echo "### ✅ Staging deployed: https://kyosan-cts-staging.vercel.app ($url)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,10 +1,11 @@
 name: Quality
 
 on:
+  # push only on dev (the integration branch). Feature branches are validated
+  # via pull_request, and main/staging run this gate through the Deploy
+  # workflow — so a feature branch with an open PR isn't checked twice.
   push:
-    # Every branch except main/staging — those run the same gate via the Deploy
-    # workflow, so triggering here too would duplicate the run.
-    branches-ignore: [main, staging]
+    branches: [dev]
   pull_request:
     branches: [main, staging, dev]
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,20 @@
+name: Quality
+
+on:
+  push:
+    # Every branch except main/staging — those run the same gate via the Deploy
+    # workflow, so triggering here too would duplicate the run.
+    branches-ignore: [main, staging]
+  pull_request:
+    branches: [main, staging, dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets:
+      TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@ Local dev requires Postgres via `docker compose up -d`: dev DB on `:5432`, ephem
 
 Git hooks (husky): **pre-commit** runs lint + typecheck + `test:unit run`; **pre-push** additionally runs `build` and `test:e2e`.
 
+## CI / Deploy
+
+GitHub Actions: `ci.yml` is a reusable workflow (lint, typecheck, unit, e2e) called by `tests.yml` (PRs + push to `dev`) and `deploy.yml` (push to `staging`/`main`). `deploy.yml` runs the quality gate, then a single environment-gated `release` job that **migrates the DB before deploying** to Vercel (`staging`→Preview, `main`→Production; Vercel Git auto-deploy is off via `vercel.json`). The `production` environment requires reviewer approval, which pauses `release` before the migration runs.
+
+Because migrations apply before the new code ships, the old code briefly runs against the new schema. **Only ship backward-compatible migrations** through this pipeline; split breaking changes into expand-then-contract steps across two deploys.
+
 ## Architecture
 
 **Type-safe RPC stack.** API runs on Hono, not Next.js route handlers. All routes mount under one catch-all (`app/api/[[...route]]/route.ts` → `server/api/app.ts`). The Hono app's chained route type is exported as `AppType`, and `lib/api-client.ts` wraps it with `hc<AppType>` so the client (`api.quizzes.$get(...)`) is fully typed end-to-end. **When adding/changing a route, keep the `.route(...)` chain in `app.ts` intact** — breaking the chain drops types from the client.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
…ipeline

Extract lint/typecheck/unit/e2e into a reusable ci.yml called by both the Quality workflow (PRs + non-deploy branch pushes) and a new Deploy workflow. Deploy migrates the DB then deploys to Vercel via prebuilt CLI (staging→Preview, main→Production), with Vercel Git auto-deploy disabled via vercel.json.